### PR TITLE
Update Installataion & Usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These instructions assume that you already have Docker and Docker-compose instal
 [here](https://docs.docker.com/compose/install/). 
 - Clone this repository to your computer
 - Navigate to the root of the project: `cd car-evaluation-project`
-- Build the docker images using `docker-compose up -d --build`
+- Build the docker images using `docker-compose -f ./packages/docker-compose.yml up -d --build`
   - This may take a minute
 - Open your browser and navigate to http://localhost:8501 to use the application. 
 


### PR DESCRIPTION
**Reason for Change:**  
I encountered some difficulties running the project using the provided usage instructions. It seems that the previous instructions assumed the `docker-compose.yml` file was located in the project root, which doesn't align with the actual project structure. Therefore, this file must be referenced using the `-f` flag while executing the `docker-compose` command. 


**Summary:**  
This pull request updates the installation and usage instructions in the documentation to align with the project structure, where the `docker-compose.yml` file resides inside the `packages` directory. The change uses the `-f` flag to refer to the `docker-compose.yml` for building and running Docker Compose services.  
